### PR TITLE
Fixup item models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out/*
 *.iws
 *.ipr
 build/*
+run/*

--- a/src/main/resources/assets/deepresonance/models/item/boots.json
+++ b/src/main/resources/assets/deepresonance/models/item/boots.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationSuitBoots"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/chest.json
+++ b/src/main/resources/assets/deepresonance/models/item/chest.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationSuitChest"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/dr_manual.json
+++ b/src/main/resources/assets/deepresonance/models/item/dr_manual.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/deepResonanceManual"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/filter.json
+++ b/src/main/resources/assets/deepresonance/models/item/filter.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/filterMaterial"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/helmet.json
+++ b/src/main/resources/assets/deepresonance/models/item/helmet.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationSuitHelmet"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/insert_liquid.json
+++ b/src/main/resources/assets/deepresonance/models/item/insert_liquid.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/liquidInjector"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/leggings.json
+++ b/src/main/resources/assets/deepresonance/models/item/leggings.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationSuitLeggings"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/radiation_module.json
+++ b/src/main/resources/assets/deepresonance/models/item/radiation_module.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationModuleItem"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/radiation_monitor0.json
+++ b/src/main/resources/assets/deepresonance/models/item/radiation_monitor0.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationMonitorItem0"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/radiation_monitor1.json
+++ b/src/main/resources/assets/deepresonance/models/item/radiation_monitor1.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationMonitorItem1"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/radiation_monitor2.json
+++ b/src/main/resources/assets/deepresonance/models/item/radiation_monitor2.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationMonitorItem2"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/radiation_monitor3.json
+++ b/src/main/resources/assets/deepresonance/models/item/radiation_monitor3.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationMonitorItem3"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/radiation_monitor4.json
+++ b/src/main/resources/assets/deepresonance/models/item/radiation_monitor4.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationMonitorItem4"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/radiation_monitor5.json
+++ b/src/main/resources/assets/deepresonance/models/item/radiation_monitor5.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationMonitorItem5"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/radiation_monitor6.json
+++ b/src/main/resources/assets/deepresonance/models/item/radiation_monitor6.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationMonitorItem6"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/radiation_monitor7.json
+++ b/src/main/resources/assets/deepresonance/models/item/radiation_monitor7.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationMonitorItem7"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/radiation_monitor8.json
+++ b/src/main/resources/assets/deepresonance/models/item/radiation_monitor8.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationMonitorItem8"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/radiation_monitor9.json
+++ b/src/main/resources/assets/deepresonance/models/item/radiation_monitor9.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/radiationMonitorItem9"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/rcl_module.json
+++ b/src/main/resources/assets/deepresonance/models/item/rcl_module.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/rclModuleItem"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/resonating_plate.json
+++ b/src/main/resources/assets/deepresonance/models/item/resonating_plate.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/resonatingPlate"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }

--- a/src/main/resources/assets/deepresonance/models/item/spent_filter.json
+++ b/src/main/resources/assets/deepresonance/models/item/spent_filter.json
@@ -1,18 +1,6 @@
 {
-  "parent": "builtin/generated",
+  "parent": "item/generated",
   "textures": {
     "layer0": "deepresonance:items/spentFilterMaterial"
-  },
-  "display": {
-    "thirdperson": {
-      "rotation": [ -90, 0, 0 ],
-      "translation": [ 0, 1, -3 ],
-      "scale": [ 0.55, 0.55, 0.55 ]
-    },
-    "firstperson": {
-      "rotation": [ 0, -135, 25 ],
-      "translation": [ 0, 4, 2 ],
-      "scale": [ 1.7, 1.7, 1.7 ]
-    }
   }
 }


### PR DESCRIPTION
Uses `item/generated` as the parent model instead of `builtin/generated` so vanilla transformations are automatically applied.

Old:
![2016-10-30_11 58 45](https://cloud.githubusercontent.com/assets/7091588/19837828/6ca80b66-9e98-11e6-8e84-9270c8537d26.png)

New:
![2016-10-30_11 57 36](https://cloud.githubusercontent.com/assets/7091588/19837826/6792e93e-9e98-11e6-9c10-02925f018858.png)
