### PR TITLE
Fix error in method description in LaserDriver

### DIFF
--- a/src/main/java/mcjty/deepresonance/integration/computers/LaserDriver.java
+++ b/src/main/java/mcjty/deepresonance/integration/computers/LaserDriver.java
@@ -38,7 +38,7 @@ public class LaserDriver {
                 return new Object[]{tile.getCrystalLiquid()};
             }
 
-            @Callback(doc="function():number; Get the currently stored liquid crystal")
+            @Callback(doc="function():number; Get the maximum liquid crystal capacity")
             public Object[] getMaxCrystalLiquid(Context c, Arguments a) {
                 return new Object[]{ConfigMachines.Laser.crystalLiquidMaximum};
             }


### PR DESCRIPTION
LaserDriver#getMaxCrystialLiquid reports the same description as LaserDriver#getCrystalLiquid.