### PR TITLE
Expand the functionality of IRadiationArmor

### DIFF
--- a/src/main/java/mcjty/deepresonance/api/IRadiationArmor.java
+++ b/src/main/java/mcjty/deepresonance/api/IRadiationArmor.java
@@ -1,10 +1,20 @@
 package mcjty.deepresonance.api;
 
+import mcjty.deepresonance.radiation.RadiationConfiguration;
+import net.minecraft.item.ItemStack;
+
 /**
  * @author canitzp
  */
 public interface IRadiationArmor {
-
-    float[] protection();
-
+    
+    default float[] protection(ItemStack armorItemStack) {
+    
+        return RadiationConfiguration.suitProtection;
+    }
+    
+    default boolean isActive(ItemStack armorItemStack) {
+        
+        return true;
+    }
 }

--- a/src/main/java/mcjty/deepresonance/api/IRadiationArmor.java
+++ b/src/main/java/mcjty/deepresonance/api/IRadiationArmor.java
@@ -8,7 +8,7 @@ import net.minecraft.item.ItemStack;
  */
 public interface IRadiationArmor {
     
-    default float[] protection(ItemStack armorItemStack) {
+    default float[] protection() {
     
         return RadiationConfiguration.suitProtection;
     }

--- a/src/main/java/mcjty/deepresonance/items/armor/ItemRadiationSuit.java
+++ b/src/main/java/mcjty/deepresonance/items/armor/ItemRadiationSuit.java
@@ -86,7 +86,7 @@ public class ItemRadiationSuit extends ItemArmor implements IRadiationArmor{
                 ItemStack stack = entity.getItemStackFromSlot(slot);
                 if (!stack.isEmpty()) {
                     if (stack.getItem() instanceof IRadiationArmor && ((IRadiationArmor) stack.getItem()).isActive(stack)) {
-                        return ((IRadiationArmor) stack.getItem()).protection(stack)[countSuitPieces(entity)];
+                        return ((IRadiationArmor) stack.getItem()).protection()[countSuitPieces(entity)];
                     } else if (stack.hasTagCompound() && stack.getTagCompound().hasKey("AntiRadiationArmor")) {
                         return RadiationConfiguration.suitProtection[countSuitPieces(entity)];
                     }

--- a/src/main/java/mcjty/deepresonance/items/armor/ItemRadiationSuit.java
+++ b/src/main/java/mcjty/deepresonance/items/armor/ItemRadiationSuit.java
@@ -69,7 +69,9 @@ public class ItemRadiationSuit extends ItemArmor implements IRadiationArmor{
         for (EntityEquipmentSlot slot : EntityEquipmentSlot.values()) {
             if (slot.getSlotType() == EntityEquipmentSlot.Type.ARMOR) {
                 ItemStack stack = entity.getItemStackFromSlot(slot);
-                if (!stack.isEmpty() && (stack.getItem() instanceof IRadiationArmor)) {
+                if (!stack.isEmpty() && (stack.getItem() instanceof IRadiationArmor) && ((IRadiationArmor)stack.getItem()).isActive(stack)) {
+                    cnt++;
+                } else if (stack.hasTagCompound() && stack.getTagCompound().hasKey("AntiRadiationArmor")) {
                     cnt++;
                 }
             }
@@ -83,8 +85,8 @@ public class ItemRadiationSuit extends ItemArmor implements IRadiationArmor{
             if (slot.getSlotType() == EntityEquipmentSlot.Type.ARMOR) {
                 ItemStack stack = entity.getItemStackFromSlot(slot);
                 if (!stack.isEmpty()) {
-                    if (stack.getItem() instanceof IRadiationArmor) {
-                        return ((IRadiationArmor) stack.getItem()).protection()[countSuitPieces(entity)];
+                    if (stack.getItem() instanceof IRadiationArmor && ((IRadiationArmor) stack.getItem()).isActive(stack)) {
+                        return ((IRadiationArmor) stack.getItem()).protection(stack)[countSuitPieces(entity)];
                     } else if (stack.hasTagCompound() && stack.getTagCompound().hasKey("AntiRadiationArmor")) {
                         return RadiationConfiguration.suitProtection[countSuitPieces(entity)];
                     }
@@ -92,10 +94,5 @@ public class ItemRadiationSuit extends ItemArmor implements IRadiationArmor{
             }
         }
         return 0;
-    }
-
-    @Override
-    public float[] protection() {
-        return RadiationConfiguration.suitProtection;
     }
 }


### PR DESCRIPTION
This PR expands on the functionality of IRadiationArmor, making it easier for other mods to provide some protection of their own.

A new method, isActive, is added that can be used to check if a given itemstack should actually count as active IRadiationArmor. By default this returns true meaning any existing mods that implement the Interface don't need to change anything.

Protection was changed to have a default implementation that returns RadiationConfiguration.suitProtection so that mods don't have to implement this method unless they specifically need to override it

ItemRadiationSuit was updated to account for these changes