### PR TITLE
1.12 Enhanced crystal stacking.

### DIFF
--- a/src/main/java/mcjty/deepresonance/blocks/crystalizer/CrystalizerTileEntity.java
+++ b/src/main/java/mcjty/deepresonance/blocks/crystalizer/CrystalizerTileEntity.java
@@ -147,9 +147,9 @@ public class CrystalizerTileEntity extends GenericEnergyReceiverTileEntity imple
         ItemStack stack = new ItemStack(ModBlocks.resonatingCrystalBlock);
         NBTTagCompound compound = new NBTTagCompound();
         compound.setFloat("power", 100.0f);
-        compound.setFloat("strength", mergedData.getStrength() * 100.0f);
-        compound.setFloat("efficiency", mergedData.getEfficiency() * 100.0f);
-        compound.setFloat("purity", mergedData.getPurity() * 100.0f);
+        compound.setFloat("strength", Math.round(mergedData.getStrength() * 1000.0f) / 10.0f);
+        compound.setFloat("efficiency", Math.round(mergedData.getEfficiency() * 1000.0f) / 10.0f);
+        compound.setFloat("purity", Math.round(mergedData.getPurity() * 1000.0f) / 10.0f);
         compound.setByte("version", (byte) 2);      // Legacy support to support older crystals.
         stack.setTagCompound(compound);
         mergedData = null;


### PR DESCRIPTION
Crystals do stack when they have the exact same stats, however, frustratingly, it is based on matching floating values making such a thing possible but complicated to do, this patch makes the stats of crystals generated by crystalisers be rounded to the closest tenth to enhance their ability to stack, so if one ever makes a process that reliably creates crystal with very close stats, they should now have the same stats and stack.
I did not bother with wild crystal at all because they have way too random stats.